### PR TITLE
Update NewConfig to return error value

### DIFF
--- a/caddynet/netserver/plugin.go
+++ b/caddynet/netserver/plugin.go
@@ -2,6 +2,7 @@ package netserver
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/mholt/caddy"
@@ -113,7 +114,10 @@ func (n *netContext) InspectServerBlocks(sourceFile string, serverBlocks []caddy
 
 		// Make our caddytls.Config, which has a pointer to the
 		// instance's certificate cache
-		caddytlsConfig := caddytls.NewConfig(n.instance)
+		caddytlsConfig, err := caddytls.NewConfig(n.instance)
+		if err != nil {
+			return serverBlocks, fmt.Errorf("creating new TLS configuration: %v", err)
+		}
 
 		// Save the config to our master list, and key it for lookups
 		c := &Config{
@@ -174,7 +178,11 @@ func GetConfig(c *caddy.Controller) *Config {
 	// is not echo or proxy i.e port number :12017
 	// we can't return a nil because caddytls.RegisterConfigGetter will panic
 	// so we return a default (blank) config value
-	caddytlsConfig := caddytls.NewConfig(ctx.instance)
+	caddytlsConfig, err := caddytls.NewConfig(ctx.instance)
+	if err != nil {
+		log.Printf("[ERROR] Making new TLS configuration: %v", err)
+		return new(Config)
+	}
 
 	return &Config{TLS: caddytlsConfig}
 }


### PR DESCRIPTION
Sorry for the breaking change here... but I had to fix a bug. The fix is in commit https://github.com/mholt/caddy/commit/0a95b5d359195dc462458f63d98d0bdb112b9f73.

I know this isn't awesome, but I might look into having a ConfigGetter also return an error value in the future...

That commit should be released in Caddy 0.11.4, probably tomorrow, Feb. 15, so you can deploy your plugin then, after merging this PR.