### PR TITLE
Bugfix: ObtainCert cannot look at the Managed flag, so we should do that instead

### DIFF
--- a/caddynet/netserver/tls.go
+++ b/caddynet/netserver/tls.go
@@ -28,12 +28,14 @@ func activateTLS(cctx caddy.Context) error {
 		}
 	}
 
-	// 3. Calls ObtainCert() for each config (this method only obtains certificates if the config qualifies and has its Managed field set to true).
+	// 3. Calls ObtainCert() for each managed config.
 	// place certificates and keys on disk
-	for _, c := range ctx.configs {
-		err := c.TLS.Manager.ObtainCert(c.TLS.Hostname, operatorPresent)
-		if err != nil {
-			return err
+	for _, cfg := range ctx.configs {
+		if cfg.TLS.Managed {
+			err := cfg.TLS.Manager.ObtainCert(cfg.TLS.Hostname, operatorPresent)
+			if err != nil {
+				return err
+			}
 		}
 
 	}


### PR DESCRIPTION
While using caddy-net, I discovered that none of the TLS directives seemed to work (tls off, tls self_signed, ...). However, setting the email address did work. The problem is that a certificate is fetched regardless of whether the TLS is being managed or not. This is incorrect and will not work on development setups where ACME fails.