### PR TITLE
Remove parameters to certCache.RenewManagedCertificates

### DIFF
--- a/caddynet/netserver/tls.go
+++ b/caddynet/netserver/tls.go
@@ -74,7 +74,7 @@ func activateTLS(cctx caddy.Context) error {
 		certCache, ok := ctx.instance.Storage[caddytls.CertCacheInstStorageKey].(*certmagic.Cache)
 		ctx.instance.StorageMu.RUnlock()
 		if ok && certCache != nil {
-			if err := certCache.RenewManagedCertificates(operatorPresent); err != nil {
+			if err := certCache.RenewManagedCertificates(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This fixes the following build error due to a signature change in the `certCache.RenewManagedCertificates` method.

```
/go/pkg/mod/github.com/pieterlouw/caddy-net@v0.1.5/caddynet/netserver/tls.go:77:48: too many arguments in call to certCache.RenewManagedCertificates
	have (bool)
	want ()
```